### PR TITLE
Add Harshlands as an optional HUD display provider

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -111,6 +111,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>cz.hashiri.harshlands</groupId>
+      <artifactId>harshlands-api</artifactId>
+      <version>1.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.sk89q.worldguard</groupId>
       <artifactId>worldguard-bukkit</artifactId>
       <version>7.1.0-SNAPSHOT</version>
@@ -130,10 +136,10 @@
     </dependency>
   </dependencies>
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <plugin.version>${project.version}</plugin.version>
     <maven.compiler.target>21</maven.compiler.target>
     <java.version>21</java.version>
     <maven.compiler.source>21</maven.compiler.source>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <plugin.version>${project.version}</plugin.version>
   </properties>
 </project>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -111,7 +111,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>cz.hashiri.harshlands</groupId>
+      <groupId>com.github.Hashiri-CZ.Harshlands</groupId>
       <artifactId>harshlands-api</artifactId>
       <version>1.3.2</version>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Harshlands API (interface-only; provided like the other API deps, never shaded) -->
+        <dependency>
+            <groupId>cz.hashiri.harshlands</groupId>
+            <artifactId>harshlands-api</artifactId>
+            <version>1.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- WorldGuard -->
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
 
         <!-- Harshlands API (interface-only; provided like the other API deps, never shaded) -->
         <dependency>
-            <groupId>cz.hashiri.harshlands</groupId>
+            <groupId>com.github.Hashiri-CZ.Harshlands</groupId>
             <artifactId>harshlands-api</artifactId>
             <version>1.3.2</version>
             <scope>provided</scope>

--- a/src/main/java/bodyhealth/Main.java
+++ b/src/main/java/bodyhealth/Main.java
@@ -13,6 +13,7 @@ import bodyhealth.effects.effect.POTION_EFFECT;
 import bodyhealth.tasks.GradualHealthRegenTask;
 import bodyhealth.listeners.BetterHudListener;
 import bodyhealth.listeners.BodyHealthListener;
+import bodyhealth.listeners.HarshlandsListener;
 import bodyhealth.listeners.PlaceholderAPIListener;
 import bodyhealth.listeners.UpdateNotifyListener;
 import bodyhealth.migrations.Migrator;
@@ -147,8 +148,9 @@ public final class Main extends JavaPlugin {
             placeholderAPIexpansion.register();
             Debug.log("Registered PlaceholderAPI expansion");
 
-            // BetterHud integration - Only works with PAPI installed
-            if (Bukkit.getPluginManager().getPlugin("BetterHud") != null && Bukkit.getPluginManager().getPlugin("BetterHud").isEnabled()) {
+            // Display integration - Only works with PAPI installed (BodyHealth's own placeholders feed the HUD)
+            if (Config.display_provider.equals("BETTERHUD")
+                    && Bukkit.getPluginManager().getPlugin("BetterHud") != null && Bukkit.getPluginManager().getPlugin("BetterHud").isEnabled()) {
                 Debug.log("BetterHud detected, enabling BetterHud integration...");
                 BetterHudListener bhl = new BetterHudListener();
                 Bukkit.getPluginManager().registerEvents(bhl, this);
@@ -165,12 +167,33 @@ public final class Main extends JavaPlugin {
                 Bukkit.getPluginManager().registerEvents(new PlaceholderAPIListener(), this);
             }
 
+            else if (Config.display_provider.equals("HARSHLANDS")
+                    && Bukkit.getPluginManager().getPlugin("Harshlands") != null && Bukkit.getPluginManager().getPlugin("Harshlands").isEnabled()) {
+                Debug.log("Harshlands detected, enabling Harshlands display integration...");
+                Bukkit.getPluginManager().registerEvents(new HarshlandsListener(), this);
+
+                /*
+                 * Harshlands may have enabled before us; re-apply HUD visibility for every
+                 * player already online once things have settled.
+                 */
+                scheduler.runTaskLater(() -> {
+                    for (Player player : Bukkit.getOnlinePlayers()) BodyHealthUtils.applyBodyHealthHudVisibility(player);
+                }, 60L);
+                Debug.log("Harshlands display integration enabled");
+            }
+
         }
 
-        else if (Bukkit.getPluginManager().getPlugin("BetterHud") != null) Debug.logErr("BetterHud integration requires PlaceholderAPI to be installed!");
+        else if (Config.display_provider.equals("BETTERHUD") && Bukkit.getPluginManager().getPlugin("BetterHud") != null)
+            Debug.logErr("BetterHud integration requires PlaceholderAPI to be installed!");
+        else if (Config.display_provider.equals("HARSHLANDS") && Bukkit.getPluginManager().getPlugin("Harshlands") != null)
+            Debug.logErr("Harshlands display integration requires PlaceholderAPI to be installed!");
 
         Plugin betterHud = Bukkit.getPluginManager().getPlugin("BetterHud");
         BodyHealthUtils.betterHudEnabled = betterHud != null && betterHud.isEnabled();
+
+        Plugin harshlands = Bukkit.getPluginManager().getPlugin("Harshlands");
+        BodyHealthUtils.harshlandsEnabled = harshlands != null && harshlands.isEnabled();
 
         // Set up DataManager
         DataManager.load();

--- a/src/main/java/bodyhealth/Main.java
+++ b/src/main/java/bodyhealth/Main.java
@@ -150,8 +150,8 @@ public final class Main extends JavaPlugin {
             placeholderAPIexpansion.register();
             Debug.log("Registered PlaceholderAPI expansion");
 
-            // Display integration - Only works with PAPI installed (BodyHealth's own placeholders feed the HUD)
-            if (Config.display_provider.equals("BETTERHUD")
+            // Load BetterHud integration
+            if (Config.display_betterhud_enabled
                     && Bukkit.getPluginManager().getPlugin("BetterHud") != null && Bukkit.getPluginManager().getPlugin("BetterHud").isEnabled()) {
                 Debug.log("BetterHud detected, enabling BetterHud integration...");
                 BetterHudListener bhl = new BetterHudListener();
@@ -169,15 +169,12 @@ public final class Main extends JavaPlugin {
                 Bukkit.getPluginManager().registerEvents(new PlaceholderAPIListener(), this);
             }
 
-            else if (Config.display_provider.equals("HARSHLANDS")
+            // Load Harshlands integration
+            if (Config.display_harshlands_enabled
                     && Bukkit.getPluginManager().getPlugin("Harshlands") != null && Bukkit.getPluginManager().getPlugin("Harshlands").isEnabled()) {
                 Debug.log("Harshlands detected, enabling Harshlands display integration...");
                 Bukkit.getPluginManager().registerEvents(new HarshlandsListener(), this);
 
-                /*
-                 * Harshlands may have enabled before us; re-apply HUD visibility for every
-                 * player already online once things have settled.
-                 */
                 scheduler.runTaskLater(() -> {
                     for (Player player : Bukkit.getOnlinePlayers()) BodyHealthUtils.applyBodyHealthHudVisibility(player);
                 }, 60L);
@@ -185,11 +182,12 @@ public final class Main extends JavaPlugin {
             }
 
         }
-
-        else if (Config.display_provider.equals("BETTERHUD") && Bukkit.getPluginManager().getPlugin("BetterHud") != null)
-            Debug.logErr("BetterHud integration requires PlaceholderAPI to be installed!");
-        else if (Config.display_provider.equals("HARSHLANDS") && Bukkit.getPluginManager().getPlugin("Harshlands") != null)
-            Debug.logErr("Harshlands display integration requires PlaceholderAPI to be installed!");
+        else {
+            if (Bukkit.getPluginManager().getPlugin("BetterHud") != null)
+                Debug.logErr("BetterHud integration requires PlaceholderAPI to be installed!");
+            if (Bukkit.getPluginManager().getPlugin("Harshlands") != null)
+                Debug.logErr("Harshlands display integration requires PlaceholderAPI to be installed!");
+        }
 
         Plugin betterHud = Bukkit.getPluginManager().getPlugin("BetterHud");
         BodyHealthUtils.betterHudEnabled = betterHud != null && betterHud.isEnabled();

--- a/src/main/java/bodyhealth/config/Config.java
+++ b/src/main/java/bodyhealth/config/Config.java
@@ -70,8 +70,7 @@ public class Config {
     public static ConfigurationSection body_damage;
     public static ConfigurationSection effects;
 
-    public static String display_provider;
-
+    public static boolean display_betterhud_enabled;
     public static boolean display_betterhud_auto_reload;
     public static boolean display_betterhud_inject_config;
     public static boolean display_betterhud_as_default;
@@ -91,6 +90,9 @@ public class Config {
 
     public static boolean display_betterhud_package_compress;
     public static String display_betterhud_package_filename;
+
+    public static boolean display_harshlands_enabled;
+    public static boolean display_harshlands_enabled_only;
 
     public static void load(FileConfiguration config) {
 
@@ -166,8 +168,7 @@ public class Config {
         body_damage = config.getConfigurationSection("body-damage");
         effects = config.getConfigurationSection("effects");
 
-        display_provider = config.getString("display.provider", "BETTERHUD").trim().toUpperCase();
-
+        display_betterhud_enabled = config.getBoolean("display.betterhud.enabled", true);
         display_betterhud_auto_reload = config.getBoolean("display.betterhud.auto-reload", true);
         display_betterhud_inject_config = config.getBoolean("display.betterhud.inject-config", true);
         display_betterhud_as_default = config.getBoolean("display.betterhud.as-default", true);
@@ -187,6 +188,9 @@ public class Config {
 
         display_betterhud_package_compress = config.getBoolean("display.betterhud.package.compress", true);
         display_betterhud_package_filename = config.getString("display.betterhud.package.filename", "resource_pack");
+
+        display_harshlands_enabled = config.getBoolean("display.harshlands.enabled", true);
+        display_harshlands_enabled_only = config.getBoolean("display.harshlands.enabled-only", true);
 
     }
 

--- a/src/main/java/bodyhealth/config/Config.java
+++ b/src/main/java/bodyhealth/config/Config.java
@@ -66,6 +66,8 @@ public class Config {
     public static ConfigurationSection body_damage;
     public static ConfigurationSection effects;
 
+    public static String display_provider;
+
     public static boolean display_betterhud_auto_reload;
     public static boolean display_betterhud_inject_config;
     public static boolean display_betterhud_as_default;
@@ -149,6 +151,8 @@ public class Config {
         body_health = config.getConfigurationSection("body-health");
         body_damage = config.getConfigurationSection("body-damage");
         effects = config.getConfigurationSection("effects");
+
+        display_provider = config.getString("display.provider", "BETTERHUD").trim().toUpperCase();
 
         display_betterhud_auto_reload = config.getBoolean("display.betterhud.auto-reload", true);
         display_betterhud_inject_config = config.getBoolean("display.betterhud.inject-config", true);

--- a/src/main/java/bodyhealth/depend/Harshlands.java
+++ b/src/main/java/bodyhealth/depend/Harshlands.java
@@ -15,7 +15,7 @@ public class Harshlands {
 
     /**
      * Enables or disables the BodyHealth HUD for a given player via the Harshlands API.
-     * @param player  the player for whom the HUD should be enabled or disabled
+     * @param player the player for whom the HUD should be enabled or disabled
      * @param enabled whether the HUD should be enabled or disabled
      * @return whether the operation changed the player's shown-state
      */

--- a/src/main/java/bodyhealth/depend/Harshlands.java
+++ b/src/main/java/bodyhealth/depend/Harshlands.java
@@ -1,0 +1,35 @@
+package bodyhealth.depend;
+
+import cz.hashiri.harshlands.api.HarshlandsAPI;
+import cz.hashiri.harshlands.api.hud.Hud;
+import cz.hashiri.harshlands.api.player.HudPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * Thin bridge to the Harshlands HUD API. The Harshlands equivalent of
+ * {@link bodyhealth.depend.BetterHud#setBodyHealthHudEnabled(Player, boolean)} -
+ * Harshlands ships its own glyphs and render task, so unlike {@link BetterHud}
+ * there is no config/asset injection to do here.
+ */
+public class Harshlands {
+
+    /**
+     * Enables or disables the BodyHealth HUD for a given player via the Harshlands API.
+     * @param player  the player for whom the HUD should be enabled or disabled
+     * @param enabled whether the HUD should be enabled or disabled
+     * @return whether the operation changed the player's shown-state
+     */
+    public static boolean setBodyHealthHudEnabled(Player player, boolean enabled) {
+        // Harshlands' BodyHealth module may be disabled in Harshlands' own config, in which case
+        // HarshlandsAPI.inst() is null even though the Harshlands plugin itself is enabled.
+        if (HarshlandsAPI.inst() == null) return false;
+
+        HudPlayer hudPlayer = HarshlandsAPI.inst().getPlayerManager().getHudPlayer(player.getUniqueId());
+        if (hudPlayer == null) return false;
+
+        Hud hud = HarshlandsAPI.inst().getHudManager().getHud("bodyhealth");
+        if (hud == null) return false;
+
+        return enabled ? hud.add(hudPlayer) : hud.remove(hudPlayer);
+    }
+}

--- a/src/main/java/bodyhealth/listeners/BodyHealthListener.java
+++ b/src/main/java/bodyhealth/listeners/BodyHealthListener.java
@@ -91,7 +91,7 @@ public class BodyHealthListener implements Listener {
                 for (BodyPart bodyPart : BodyPart.values()) {
                     BodyHealthUtils.applyDamageWithConfig(bodyHealth, cause, damage, bodyPart, false, event);
                 }
-                Debug.logDev("Player " + player.getName() + " was hit by a block that couldn't be retrieved because of a bug in your server software (https://github.com/PaperMC/Paper/issues/11984) applying " + String.format("%.2f", damage) + " damage to all body parts.");
+                Debug.logDev("Player " + player.getName() + " was hit by a block that couldn't be retrieved because of a bug in your server software (https://github.com/PaperMC/Paper/issues/11984), applying " + String.format("%.2f", damage) + " damage to all body parts.");
                 return;
             }
 

--- a/src/main/java/bodyhealth/listeners/HarshlandsListener.java
+++ b/src/main/java/bodyhealth/listeners/HarshlandsListener.java
@@ -1,0 +1,24 @@
+package bodyhealth.listeners;
+
+import bodyhealth.util.BodyHealthUtils;
+import cz.hashiri.harshlands.api.bukkit.event.PluginReloadedEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+/**
+ * Harshlands clears its per-player "shown" set on /hl reload, so when Harshlands
+ * reloads we re-issue Hud.add for every online player. The Harshlands equivalent of
+ * {@link BetterHudListener}, but trivial - Harshlands ships its own glyphs, so there
+ * is no config/asset re-injection to do.
+ */
+public class HarshlandsListener implements Listener {
+
+    @EventHandler
+    public void onHarshlandsReloaded(PluginReloadedEvent event) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            BodyHealthUtils.applyBodyHealthHudVisibility(player);
+        }
+    }
+}

--- a/src/main/java/bodyhealth/util/BodyHealthUtils.java
+++ b/src/main/java/bodyhealth/util/BodyHealthUtils.java
@@ -10,6 +10,7 @@ import bodyhealth.core.BodyPart;
 import bodyhealth.core.BodyPartState;
 import bodyhealth.data.DataManager;
 import bodyhealth.depend.BetterHud;
+import bodyhealth.depend.Harshlands;
 import bodyhealth.depend.WorldGuard;
 import bodyhealth.effects.EffectHandler;
 import bodyhealth.effects.effect.POTION_EFFECT;
@@ -37,10 +38,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
 
 public class BodyHealthUtils {
 
     public static boolean betterHudEnabled = false;
+    public static boolean harshlandsEnabled = false;
 
     private static final Method ADD_TRANSIENT_MODIFIER;
     static {
@@ -144,6 +147,9 @@ public class BodyHealthUtils {
         Plugin betterHud = Bukkit.getPluginManager().getPlugin("BetterHud");
         betterHudEnabled = betterHud != null && betterHud.isEnabled();
 
+        Plugin harshlands = Bukkit.getPluginManager().getPlugin("Harshlands");
+        harshlandsEnabled = harshlands != null && harshlands.isEnabled();
+
         return true;
     }
 
@@ -176,13 +182,21 @@ public class BodyHealthUtils {
      * @param player The player to do this for
      */
     public static void applyBodyHealthHudVisibility(Player player) {
-        if (!betterHudEnabled) return;
+        switch (Config.display_provider) {
+            case "BETTERHUD"  -> applyHudVisibility(player, betterHudEnabled,  BetterHud::setBodyHealthHudEnabled);
+            case "HARSHLANDS" -> applyHudVisibility(player, harshlandsEnabled, Harshlands::setBodyHealthHudEnabled);
+            default           -> { /* NONE or unrecognised provider - render no HUD */ }
+        }
+    }
+
+    private static void applyHudVisibility(Player player, boolean providerActive, BiPredicate<Player, Boolean> setter) {
+        if (!providerActive) return;
         if (!Config.display_betterhud_enabled_only) {
-            BetterHud.setBodyHealthHudEnabled(player, true);
+            setter.test(player, true);
             return;
         }
         boolean enabled = isSystemEnabled(player);
-        boolean changed = BetterHud.setBodyHealthHudEnabled(player, enabled);
+        boolean changed = setter.test(player, enabled);
         if (changed) Debug.logDev((enabled ? "Enabled" : "Disabled") + " BodyHealth's HUD for player " + player.getName() + ".");
     }
 

--- a/src/main/java/bodyhealth/util/BodyHealthUtils.java
+++ b/src/main/java/bodyhealth/util/BodyHealthUtils.java
@@ -156,16 +156,15 @@ public class BodyHealthUtils {
      * @param player The player to do this for
      */
     public static void applyBodyHealthHudVisibility(Player player) {
-        switch (Config.display_provider) {
-            case "BETTERHUD"  -> applyHudVisibility(player, betterHudEnabled,  BetterHud::setBodyHealthHudEnabled);
-            case "HARSHLANDS" -> applyHudVisibility(player, harshlandsEnabled, Harshlands::setBodyHealthHudEnabled);
-            default           -> { /* NONE or unrecognised provider - render no HUD */ }
-        }
+        if (Config.display_betterhud_enabled)
+            applyHudVisibility(player, betterHudEnabled,  BetterHud::setBodyHealthHudEnabled, Config.display_betterhud_enabled_only);
+        if (Config.display_harshlands_enabled)
+            applyHudVisibility(player, harshlandsEnabled, Harshlands::setBodyHealthHudEnabled, Config.display_harshlands_enabled_only);
     }
 
-    private static void applyHudVisibility(Player player, boolean providerActive, BiPredicate<Player, Boolean> setter) {
+    private static void applyHudVisibility(Player player, boolean providerActive, BiPredicate<Player, Boolean> setter, boolean enabledOnly) {
         if (!providerActive) return;
-        if (!Config.display_betterhud_enabled_only) {
+        if (!enabledOnly) {
             setter.test(player, true);
             return;
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -520,15 +520,9 @@ effects:
       - MESSAGE / actionbar:&cYou sprained your ankle
 
 
+# Optional HUD display settings
+# Choose one (or none)
 display:
-
-  #   Which plugin renders your body health on screen:
-  #      BETTERHUD  - use BetterHud            (requires BetterHud + PlaceholderAPI; configure under "betterhud:" below)
-  #      HARSHLANDS - use the Harshlands plugin (requires Harshlands + PlaceholderAPI; Harshlands ships its own
-  #                                              resource pack and HUD position - there is nothing to configure here
-  #                                              and no resource pack to generate)
-  #      NONE       - render no HUD             (the bodyhealth_* placeholders still work for your own HUD setup)
-  provider: BETTERHUD
 
   #   Use BetterHud to display your body health in game:
   #
@@ -538,6 +532,8 @@ display:
   #
   #   When both plugins are installed, the following options activate:
   betterhud:
+    # Use BetterHud (if available) to display BodyHealth's HUD
+    enabled: true
     # Automatically reload BetterHud with BodyHealth to apply changes
     auto-reload: true
     # Automatically configure BetterHud to display BodyHealth's HUD
@@ -545,7 +541,6 @@ display:
     # Show BodyHealth's HUD to all players **IN SURVIVAL/ADVENTURE MODE**
     as-default: true
     # Show BodyHealth's HUD only in worlds/regions where BodyHealth is enabled
-    # (this option also applies when display.provider is HARSHLANDS)
     enabled-only: true
     # Position BodyHealth's HUD on your screen (REQUIRES REGENERATING THE RESOURCE PACK)
     position:
@@ -582,6 +577,20 @@ display:
     # LOCATED AT "plugins/BodyHealth/output/resource_pack.zip" TO VISUALIZE HEALTH PER BODY PART
     # (YOU STILL NEED TO DOWNLOAD BOTH DEPENDENCIES FOR THIS TO WORK)
 
+    #   Use Harshlands to display your body health in game:
+    #
+    #      To make this work, you need to install two plugins, if you don't have them already:       <--
+    #      PlaceholderAPI -> https://www.spigotmc.org/resources/placeholderapi.6245/               <-- DON'T OVERLOOK THIS PART
+    #      …and obviously Harshlands -> https://github.com/Hashiri-CZ/Harshlands/releases            <--
+    #
+    #      You also need to enable the 'BodyHealth' module in your Harshlands config.yml
+    #
+    #   When both plugins are installed, the following options activate:
+    harshlands:
+      # Use Harshlands (if available) to display BodyHealth's HUD
+      enabled: true
+      # Show BodyHealth's HUD only in worlds/regions where BodyHealth is enabled
+      enabled-only: true
 
     # !!! ItemsAdder users read here !!!
     # ItemsAdder interferes with BetterHud on default settings. If you can't see the display

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -508,6 +508,14 @@ effects:
 
 display:
 
+  #   Which plugin renders your body health on screen:
+  #      BETTERHUD  - use BetterHud            (requires BetterHud + PlaceholderAPI; configure under "betterhud:" below)
+  #      HARSHLANDS - use the Harshlands plugin (requires Harshlands + PlaceholderAPI; Harshlands ships its own
+  #                                              resource pack and HUD position - there is nothing to configure here
+  #                                              and no resource pack to generate)
+  #      NONE       - render no HUD             (the bodyhealth_* placeholders still work for your own HUD setup)
+  provider: BETTERHUD
+
   #   Use BetterHud to display your body health in game:
   #
   #      To make this work, you need to install two plugins, if you don't have them already:       <--
@@ -523,6 +531,7 @@ display:
     # Show BodyHealth's HUD to all players **IN SURVIVAL/ADVENTURE MODE**
     as-default: true
     # Show BodyHealth's HUD only in worlds/regions where BodyHealth is enabled
+    # (this option also applies when display.provider is HARSHLANDS)
     enabled-only: true
     # Position BodyHealth's HUD on your screen (REQUIRES REGENERATING THE RESOURCE PACK)
     position:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,6 +10,7 @@ website: https://github.com/Mitality/BodyHealth
 softdepend:
   - PlaceholderAPI
   - BetterHud
+  - Harshlands
   - WorldGuard
 
 commands:


### PR DESCRIPTION
Adds [Harshlands] (https://github.com/Hashiri-CZ/Harshlands) as an alternative to BetterHud for rendering the BodyHealth HUD, selected via a new `display.provider` config option.

Default is `BETTERHUD`, so behavior for existing users is unchanged.